### PR TITLE
FIX: Typo on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ type user struct {
 }
 // implement UnmarshalerObject
 func (u *user) UnmarshalObject(dec *gojay.Decoder, key string) error {
-    switch k {
+    switch key {
     case "id":
         return dec.AddInt(&u.id)
     case "name":


### PR DESCRIPTION
@francoispqt This pull request fixes a typo on README.md over the sample code in the Decoding section.