### PR TITLE
Fix bug in README.md decoding example

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ func (u *user) NKeys() int {
 func main() {
     u := &user{}
     d := []byte(`{"id":1,"name":"gojay","email":"gojay@email.com"}`)
-    err := gojay.UnmarshalObject(d, user)
+    err := gojay.UnmarshalObject(d, u)
     if err != nil {
         log.Fatal(err)
     }


### PR DESCRIPTION
In the decoding example in the README, gojay.UnmarshalObject was called with a type name instead of an object.