### PR TITLE
Added MarshalAny() support

### DIFF
--- a/encode_object_test.go
+++ b/encode_object_test.go
@@ -274,6 +274,22 @@ func TestEncoderObjectMarshalAPI(t *testing.T) {
 			string(r),
 			"Result of marshalling is different as the one expected")
 	})
+	t.Run("marshal-any-object", func(t *testing.T) {
+		test := struct {
+			Foo string
+			Bar int
+		}{
+			"test",
+			100,
+		}
+		r, err := MarshalAny(test)
+		assert.Nil(t, err, "Error should be nil")
+		assert.Equal(
+			t,
+			`{"Foo":"test","Bar":100}`,
+			string(r),
+			"Result of marshalling is different as the one expected")
+	})
 }
 
 type TestObectOmitEmpty struct {


### PR DESCRIPTION
This is not breaking current `API` but provides a huge effort if you need a fallback for a marshaller.
In cases you don't need a speed, but want to be sure that your object will be marshalled, if it's possible by default golang **json** implementation.

Thank you!