### PR TITLE
MsgPack benchmarks

### DIFF
--- a/benchmarks/decoder/decoder_bench_large_test.go
+++ b/benchmarks/decoder/decoder_bench_large_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/francoispqt/gojay/benchmarks"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/mailru/easyjson"
+	"github.com/vmihailenco/msgpack"
 )
 
 func BenchmarkJsonParserDecodeObjLarge(b *testing.B) {
@@ -39,6 +40,14 @@ func BenchmarkEasyJsonDecodeObjLarge(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		result := benchmarks.LargePayload{}
 		easyjson.Unmarshal(benchmarks.LargeFixture, &result)
+	}
+}
+
+func BenchmarkMsgPackDecodeObjLarge(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		result := benchmarks.LargePayload{}
+		msgpack.Unmarshal(benchmarks.LargeFixture, &result)
 	}
 }
 

--- a/benchmarks/decoder/decoder_bench_medium_test.go
+++ b/benchmarks/decoder/decoder_bench_medium_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/francoispqt/gojay/benchmarks"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/mailru/easyjson"
+	msgpack "github.com/vmihailenco/msgpack"
 )
 
 func BenchmarkJsonIterDecodeObjMedium(b *testing.B) {
@@ -50,6 +51,15 @@ func BenchmarkEasyJsonDecodeObjMedium(b *testing.B) {
 		easyjson.Unmarshal(benchmarks.MediumFixture, &result)
 	}
 }
+
+func BenchmarkMsgPackDecodeObjMedium(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		result := benchmarks.MediumPayload{}
+		msgpack.Unmarshal(benchmarks.MediumFixture, &result)
+	}
+}
+
 func BenchmarkGoJayDecodeObjMedium(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {

--- a/benchmarks/decoder/decoder_bench_small_test.go
+++ b/benchmarks/decoder/decoder_bench_small_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/francoispqt/gojay/benchmarks"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/mailru/easyjson"
+	"github.com/vmihailenco/msgpack"
 )
 
 func BenchmarkJSONDecodeObjSmall(b *testing.B) {
@@ -49,6 +50,14 @@ func BenchmarkEasyJsonDecodeObjSmall(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		result := benchmarks.SmallPayload{}
 		easyjson.Unmarshal(benchmarks.SmallFixture, &result)
+	}
+}
+
+func BenchmarkMsgPackDecodeObjSmall(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		result := benchmarks.SmallPayload{}
+		msgpack.Unmarshal(benchmarks.SmallFixture, &result)
 	}
 }
 

--- a/benchmarks/encoder/encoder_bench_large_test.go
+++ b/benchmarks/encoder/encoder_bench_large_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/francoispqt/gojay/benchmarks"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/mailru/easyjson"
+	"github.com/vmihailenco/msgpack"
 )
 
 func BenchmarkEncodingJsonEncodeLargeStruct(b *testing.B) {
@@ -33,6 +34,15 @@ func BenchmarkEasyJsonEncodeObjLarge(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		if _, err := easyjson.Marshal(benchmarks.NewLargePayload()); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkMsgPackEncodeObjLarge(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, err := msgpack.Marshal(benchmarks.NewLargePayload()); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/benchmarks/encoder/encoder_bench_medium_test.go
+++ b/benchmarks/encoder/encoder_bench_medium_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/francoispqt/gojay/benchmarks"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/mailru/easyjson"
+	"github.com/vmihailenco/msgpack"
 )
 
 func BenchmarkEncodingJsonEncodeMediumStruct(b *testing.B) {
@@ -34,6 +35,15 @@ func BenchmarkEasyJsonEncodeObjMedium(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		if _, err := easyjson.Marshal(benchmarks.NewMediumPayload()); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkMsgPackEncodeObjMedium(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, err := msgpack.Marshal(benchmarks.NewMediumPayload()); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/benchmarks/encoder/encoder_bench_small_test.go
+++ b/benchmarks/encoder/encoder_bench_small_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/francoispqt/gojay/benchmarks"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/mailru/easyjson"
+	"github.com/vmihailenco/msgpack"
 )
 
 func BenchmarkEncodingJsonEncodeSmallStruct(b *testing.B) {
@@ -24,6 +25,15 @@ func BenchmarkEasyJsonEncodeObjSmall(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		if _, err := easyjson.Marshal(benchmarks.NewSmallPayload()); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkMsgPackEncodeObjSmall(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, err := msgpack.Marshal(benchmarks.NewSmallPayload()); err != nil {
 			b.Fatal(err)
 		}
 	}


### PR DESCRIPTION
I think it would be fair and transparent to add benchmark results for msgpack v2.

Contrasting gojay to msgpack, it becomes clear that gojay clearly has its advantages for small and linear structures, but is outperformed with large ones.