### PR TITLE
Update cursor after null correctly

### DIFF
--- a/decode_number_float.go
+++ b/decode_number_float.go
@@ -35,6 +35,7 @@ func (dec *Decoder) decodeFloat64(v *float64) error {
 			if err != nil {
 				return err
 			}
+			dec.cursor++
 			return nil
 		default:
 			dec.err = dec.makeInvalidUnmarshalErr(v)
@@ -184,6 +185,7 @@ func (dec *Decoder) decodeFloat32(v *float32) error {
 			if err != nil {
 				return err
 			}
+			dec.cursor++
 			return nil
 		default:
 			dec.err = dec.makeInvalidUnmarshalErr(v)

--- a/decode_number_int.go
+++ b/decode_number_int.go
@@ -471,6 +471,7 @@ func (dec *Decoder) decodeInt32(v *int32) error {
 			if err != nil {
 				return err
 			}
+			dec.cursor++
 			return nil
 		default:
 			dec.err = dec.makeInvalidUnmarshalErr(v)
@@ -658,6 +659,7 @@ func (dec *Decoder) decodeInt64(v *int64) error {
 			if err != nil {
 				return err
 			}
+			dec.cursor++
 			return nil
 		default:
 			dec.err = dec.makeInvalidUnmarshalErr(v)

--- a/decode_number_uint.go
+++ b/decode_number_uint.go
@@ -39,6 +39,7 @@ func (dec *Decoder) decodeUint8(v *uint8) error {
 			if err != nil {
 				return err
 			}
+			dec.cursor++
 			return nil
 		default:
 			dec.err = dec.makeInvalidUnmarshalErr(v)
@@ -108,6 +109,7 @@ func (dec *Decoder) decodeUint16(v *uint16) error {
 			if err != nil {
 				return err
 			}
+			dec.cursor++
 			return nil
 		default:
 			dec.err = dec.makeInvalidUnmarshalErr(v)
@@ -177,6 +179,7 @@ func (dec *Decoder) decodeUint32(v *uint32) error {
 			if err != nil {
 				return err
 			}
+			dec.cursor++
 			return nil
 		default:
 			dec.err = dec.makeInvalidUnmarshalErr(v)
@@ -245,6 +248,7 @@ func (dec *Decoder) decodeUint64(v *uint64) error {
 			if err != nil {
 				return err
 			}
+			dec.cursor++
 			return nil
 		default:
 			dec.err = dec.makeInvalidUnmarshalErr(v)


### PR DESCRIPTION
I noticed some errors on parsing object data and this patch seems correct. Do let me know if I am making some incorrect assumptions here! And thanks v. much for a nice library :)

> For a number of types of field value contained within an object, a
> null value would result in errors of the form:
> 
> Invalid JSON, wrong char 'l' found at position xx
> 
> This appears to be due to the cursor not consistently being updated
> after the null value is detected.
> 
> This patch resolves the issue by consistently updating the cursor in
> each case.