### PR TITLE
Add support for negative floats with 0 significand

### DIFF
--- a/decode_number_float.go
+++ b/decode_number_float.go
@@ -53,7 +53,7 @@ func (dec *Decoder) getFloatNegative() (float64, error) {
 	// look for following numbers
 	for ; dec.cursor < dec.length || dec.read(); dec.cursor++ {
 		switch dec.data[dec.cursor] {
-		case '1', '2', '3', '4', '5', '6', '7', '8', '9':
+		case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
 			return dec.getFloat()
 		default:
 			return 0, dec.raiseInvalidJSONErr(dec.cursor)
@@ -203,7 +203,7 @@ func (dec *Decoder) getFloat32Negative() (float32, error) {
 	// look for following numbers
 	for ; dec.cursor < dec.length || dec.read(); dec.cursor++ {
 		switch dec.data[dec.cursor] {
-		case '1', '2', '3', '4', '5', '6', '7', '8', '9':
+		case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
 			return dec.getFloat32()
 		default:
 			return 0, dec.raiseInvalidJSONErr(dec.cursor)

--- a/decode_number_float_test.go
+++ b/decode_number_float_test.go
@@ -195,6 +195,11 @@ func TestDecoderFloat64(t *testing.T) {
 			expectedResult: -788.76,
 		},
 		{
+			name:           "basic-float3",
+			json:           "-0.1234",
+			expectedResult: -0.1234,
+		},
+		{
 			name:           "basic-exp-too-big",
 			json:           "1e10000000000 ",
 			expectedResult: 0,
@@ -537,6 +542,11 @@ func TestDecoderFloat32(t *testing.T) {
 			name:           "basic-float2",
 			json:           "-7.8876e002",
 			expectedResult: -788.76,
+		},
+		{
+			name:           "basic-float3",
+			json:           "-0.1234",
+			expectedResult: -0.1234,
 		},
 		{
 			name:           "error",


### PR DESCRIPTION
Previously, floating point numbers of the form -0.1234..., i.e. those
with a 0 significand would result in a 'wrong char' error.

These are valid numbers in JSON under RFC 4627 so we should support
them. This patch adds this support and a test for both float64 and
float32.