### PR TITLE
fix a bug when dec reach to the end with an open \"

### DIFF
--- a/decode_array.go
+++ b/decode_array.go
@@ -79,7 +79,7 @@ func (dec *Decoder) skipArray() (int, error) {
 			arraysOpen++
 		case '"':
 			j++
-			for ; j < dec.length; j++ {
+			for ; j < dec.length || dec.read(); j++ {
 				if dec.data[j] != '"' {
 					continue
 				}


### PR DESCRIPTION
This happens in `skipArray`.

The string skipping part ignores the fact decode only has a limited buffer