### PR TITLE
Fixed incorrect unmarshalling of numbers in scientific format in several cases

### DIFF
--- a/decode_number.go
+++ b/decode_number.go
@@ -61,7 +61,7 @@ func init() {
 
 	for i := 0; i < 256; i++ {
 		switch i {
-		case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.':
+		case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.', 'e', 'E', '+', '-':
 			skipNumberEndCursorIncrement[i] = 1
 		}
 	}
@@ -74,7 +74,7 @@ func (dec *Decoder) skipNumber() (int, error) {
 		end += skipNumberEndCursorIncrement[dec.data[j]]
 
 		switch dec.data[j] {
-		case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.', ' ', '\n', '\t', '\r':
+		case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.', 'e', 'E', '+', '-', ' ', '\n', '\t', '\r':
 			continue
 		case ',', '}', ']':
 			return end, nil


### PR DESCRIPTION
Hello.
The current version can't unmarshal numbers in scientific notation in several cases.
Attached is an example of error.

[example.zip](https://github.com/francoispqt/gojay/files/2583882/example.zip)

