### PR TITLE
gojay: support custom tagname

### DIFF
--- a/gojay/gen.go
+++ b/gojay/gen.go
@@ -21,6 +21,7 @@ type Gen struct {
 	pkg      string
 	src      string
 	types    []string
+	tag      string
 	genTypes map[string]*ast.TypeSpec
 	vis      *vis
 }
@@ -52,12 +53,13 @@ func parseTemplates(tpls templateList, pfx string) {
 }
 
 // NewGen returns a new generator
-func NewGen(p string, types []string) *Gen {
+func NewGen(p string, types []string, tag string) *Gen {
 	g := &Gen{
 		src:      p,
 		types:    types,
 		b:        &strings.Builder{},
 		genTypes: make(map[string]*ast.TypeSpec),
+		tag:      tag,
 	}
 	return g
 }

--- a/gojay/gen_struct_marshal.go
+++ b/gojay/gen_struct_marshal.go
@@ -31,10 +31,10 @@ func (g *Gen) structGenMarshalObj(n string, s *ast.StructType) (int, error) {
 			// check if has hide tag
 			var omitEmpty string
 			if field.Tag != nil {
-				if hasTagMarshalHide(field.Tag) {
+				if hasTagMarshalHide(field.Tag, g.tag) {
 					continue
 				}
-				if hasTagOmitEmpty(field.Tag) {
+				if hasTagOmitEmpty(field.Tag, g.tag) {
 					omitEmpty = omitEmptyFuncName
 				}
 			}
@@ -67,7 +67,7 @@ func (g *Gen) structGenMarshalObj(n string, s *ast.StructType) (int, error) {
 }
 
 func (g *Gen) structGenMarshalIdent(field *ast.Field, i *ast.Ident, keys int, omitEmpty string, ptr bool) (int, error) {
-	var keyV = getStructFieldJSONKey(field)
+	var keyV = getStructFieldJSONKey(field, g.tag)
 
 	switch i.String() {
 	case "string":

--- a/gojay/gen_struct_unmarshal.go
+++ b/gojay/gen_struct_unmarshal.go
@@ -38,7 +38,7 @@ func (g *Gen) structGenUnmarshalObj(n string, s *ast.StructType) (int, error) {
 		// add accordingly
 		for _, field := range s.Fields.List {
 			// check if has hide tag
-			if field.Tag != nil && hasTagUnmarshalHide(field.Tag) {
+			if field.Tag != nil && hasTagUnmarshalHide(field.Tag, g.tag) {
 				continue
 			}
 			switch t := field.Type.(type) {
@@ -72,7 +72,7 @@ func (g *Gen) structGenUnmarshalObj(n string, s *ast.StructType) (int, error) {
 }
 
 func (g *Gen) structGenUnmarshalIdent(field *ast.Field, i *ast.Ident, keys int, ptr bool) (int, error) {
-	var keyV = getStructFieldJSONKey(field)
+	var keyV = getStructFieldJSONKey(field, g.tag)
 
 	switch i.String() {
 	case "string":

--- a/gojay/gen_stuct.go
+++ b/gojay/gen_stuct.go
@@ -5,10 +5,10 @@ import (
 	"strings"
 )
 
-func getStructFieldJSONKey(field *ast.Field) string {
+func getStructFieldJSONKey(field *ast.Field, tagName string) string {
 	var keyV string
 	if field.Tag != nil {
-		keyV = tagKeyName(field.Tag)
+		keyV = tagKeyName(field.Tag, tagName)
 	}
 	if keyV == "" {
 		keyV = strings.ToLower(field.Names[0].String()[:1]) + field.Names[0].String()[1:]

--- a/gojay/gen_tag.go
+++ b/gojay/gen_tag.go
@@ -13,20 +13,21 @@ const unmarshalHideTag = "-u"
 const marshalHideTag = "-m"
 const omitEmptyTag = "omitempty"
 
-func getGojayTagValue(tags *ast.BasicLit) (*structtag.Tag, error) {
+func getGojayTagValue(tags *ast.BasicLit, tagName string) (*structtag.Tag, error) {
 	t, err := structtag.Parse(tags.Value[1 : len(tags.Value)-1])
 	if err != nil {
 		return nil, err
 	}
-	v, err := t.Get(gojayTag)
+
+	v, err := t.Get(tagName)
 	if err != nil {
 		return nil, err
 	}
 	return v, nil
 }
 
-func hasTagUnmarshalHide(tags *ast.BasicLit) bool {
-	v, err := getGojayTagValue(tags)
+func hasTagUnmarshalHide(tags *ast.BasicLit, tagName string) bool {
+	v, err := getGojayTagValue(tags, tagName)
 	if err != nil {
 		log.Print(err)
 		return false
@@ -34,8 +35,8 @@ func hasTagUnmarshalHide(tags *ast.BasicLit) bool {
 	return (v.Name == unmarshalHideTag || v.Name == hideTag) || v.HasOption(unmarshalHideTag)
 }
 
-func hasTagMarshalHide(tags *ast.BasicLit) bool {
-	v, err := getGojayTagValue(tags)
+func hasTagMarshalHide(tags *ast.BasicLit, tagName string) bool {
+	v, err := getGojayTagValue(tags, tagName)
 	if err != nil {
 		log.Print(err)
 		return false
@@ -43,8 +44,8 @@ func hasTagMarshalHide(tags *ast.BasicLit) bool {
 	return (v.Name == marshalHideTag || v.Name == hideTag) || v.HasOption(marshalHideTag)
 }
 
-func hasTagOmitEmpty(tags *ast.BasicLit) bool {
-	v, err := getGojayTagValue(tags)
+func hasTagOmitEmpty(tags *ast.BasicLit, tagName string) bool {
+	v, err := getGojayTagValue(tags, tagName)
 	if err != nil {
 		log.Print(err)
 		return false
@@ -52,8 +53,8 @@ func hasTagOmitEmpty(tags *ast.BasicLit) bool {
 	return v.Name == omitEmptyTag || v.HasOption(omitEmptyTag)
 }
 
-func tagKeyName(tags *ast.BasicLit) string {
-	v, err := getGojayTagValue(tags)
+func tagKeyName(tags *ast.BasicLit, tagName string) string {
+	v, err := getGojayTagValue(tags, tagName)
 	if err != nil {
 		log.Print(err)
 		return ""

--- a/gojay/gen_test.go
+++ b/gojay/gen_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func MakeGenFromReader(input io.Reader) (*Gen, error) {
-	g := NewGen("", []string{})
+	g := NewGen("", []string{}, gojayTag)
 	fset := token.NewFileSet()
 	f, err := parser.ParseFile(fset, "", input, parser.ParseComments)
 	if err != nil {

--- a/gojay/main.go
+++ b/gojay/main.go
@@ -16,6 +16,7 @@ var dst = flag.String("o", "", "destination file to output generated implementat
 var src = flag.String("s", "", "source dir or file (absolute or relative path)")
 var pkg = flag.String("p", "", "go package")
 var types = flag.String("t", "", "types to generate")
+var tag = flag.String("g", "gojay", "tag for gojay generator")
 
 var ErrNoPathProvided = errors.New("You must provide a path or a package name")
 
@@ -98,7 +99,7 @@ func main() {
 		log.Fatal(err)
 	}
 	// parse source files
-	g := NewGen(p, t)
+	g := NewGen(p, t, *tag)
 	err = g.parse()
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
add "-g" option to enable user use other tag name instead of "gojay", for example, "json".

hope to make adopt gojay for existing code easier.

