### PR TITLE
Use writer lock for cancel.

### DIFF
--- a/encode_stream.go
+++ b/encode_stream.go
@@ -125,14 +125,15 @@ func (s *StreamEncoder) Value(key interface{}) interface{} {
 //
 // After calling cancel, Done() will return a closed channel.
 func (s *StreamEncoder) Cancel(err error) {
-	s.mux.RLock()
+	s.mux.Lock()
+	defer s.mux.Unlock()
+	
 	select {
 	case <-s.done:
 	default:
 		s.err = err
 		close(s.done)
 	}
-	s.mux.RUnlock()
 }
 
 // AddObject adds an object to be encoded.


### PR DESCRIPTION
Fixes #97

By using the writer lock, you ensure that close is called only once. Closing the chan should be seen as a write operation and not a read operation. 

By using the read lock, there is a possibility that concurrent calls to cancel will cause a panic. Using a write lock fixes this.