### PR TITLE
Continuous fuzzing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: bionic
+
 language: go
 
 go:
@@ -5,11 +7,32 @@ go:
   - "1.11.x"
   - "1.12.x"
 
+services:
+  - docker
+
+env:
+  global:
+    # FUZZIT_API_KEY
+    secure: "FEm1wF/Ttd5RIvDPg5I/aSAhBWuvkvjmkInFxlVKP4BfLsR1B1ogXV4zKFQiZugyppBta+qP4qP+tSbThSvP9JOCr+/ivnTyYLg/DH1RfQnC7rJmAaZwHGHB+NwblRzU621uIZ4RVvaE391YVJf5519gc+M+bxZ6DO0ScdpbIAVV/7JR9c7Tuvoyi57/MEwAS39k7h83ms8JgRYwuvzpVH9nb6AfYs+CzXuRlsG5mHqFnmzLyG0ewnqh18OoWbyKQwBmM+EoIGmckM8NQZaXWBhEuDP7qdl+QatNfZtK3YwBx2plahBXXMee3NpOAEHOkWxNw1uMb1B8ILDrzrx8oX1A4fF/ZeJl7JLZS/fQUMhDnLG5soA0xaEoAvwhQIHFi3e207rsq9UJsnQlRGhRWzMvx85UR5z+yiur8nVUkogu1DGpH/BPdWbTs+d8behSr7t6Sepo7enjJOPJLz6U67JlP31HvnaLICMEXxJy54BAbdu/47vqFp15lcIMHyDzPltHHWi6uGuRFQPYz8pM5ZAKQ945dO/ZELyEHbjUiLTMFeVoANzahuY56BX6hvsygcOlBWB6ukoJANvxgvM/QYkbh9dMBajYsZqHCWOKRVbBakkqPAUqkBNPOADTp5ZgUwmRySIGzX2X+Efl7cFYZVu+IJl968F8hqYajvS/VCs="
+
 script:
   - go get github.com/golang/dep/cmd/dep github.com/stretchr/testify
   - dep ensure -v -vendor-only
   - go test ./gojay/codegen/test/... -race
   - go test -race -coverprofile=coverage.txt -covermode=atomic
+
+jobs:
+  include:
+    - stage: Fuzz regression
+      go: 1.12.x
+      script:
+        - ./fuzzit.sh local-regression
+
+    - stage: Fuzz
+      if: branch = master AND type IN (push)
+      go: 1.12.x
+      script:
+        - ./fuzzit.sh fuzzing
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 ![MIT License](https://img.shields.io/badge/license-mit-blue.svg?style=flat-square)
 [![Sourcegraph](https://sourcegraph.com/github.com/francoispqt/gojay/-/badge.svg)](https://sourcegraph.com/github.com/francoispqt/gojay)
 ![stability-stable](https://img.shields.io/badge/stability-stable-green.svg)
+[![fuzzit](https://app.fuzzit.dev/badge?org_id=francoispqt)](https://app.fuzzit.dev/orgs/francoispqt/dashboard)
 
 # GoJay
 

--- a/fuzzit.sh
+++ b/fuzzit.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -xe
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <fuzz-type>"
+    exit 1
+fi
+
+NAME=gojay
+TYPE=$1
+
+function fuzz {
+    TARGET=$NAME-$1
+    FUNCTION=Fuzz$2
+    go-fuzz-build -libfuzzer -func $FUNCTION -o fuzzer.a .
+    clang -fsanitize=fuzzer fuzzer.a -o fuzzer
+    ./fuzzit create job --type $TYPE $TARGET fuzzer
+}
+
+# Setup
+export GO111MODULE="off"
+go get -u github.com/dvyukov/go-fuzz/go-fuzz github.com/dvyukov/go-fuzz/go-fuzz-build
+dep ensure -v
+wget -q -O fuzzit https://github.com/fuzzitdev/fuzzit/releases/download/v2.4.29/fuzzit_Linux_x86_64
+chmod a+x fuzzit
+
+# Fuzz
+fuzz unmarshal Unmarshal
+fuzz decode Decode
+fuzz stream Stream

--- a/gojay_fuzz.go
+++ b/gojay_fuzz.go
@@ -1,0 +1,69 @@
+// +build gofuzz
+
+package gojay
+
+import (
+	"bytes"
+	"strings"
+)
+
+func FuzzUnmarshal(input []byte) int {
+	var result *unmarshalTarget
+	err := UnmarshalJSONObject(input, result)
+	if err != nil {
+		return 0
+	}
+	return 1
+}
+
+func FuzzDecode(input []byte) int {
+	var result *interface{}
+	decoder := NewDecoder(bytes.NewReader(input))
+	defer decoder.Release()
+	err := decoder.Decode(result)
+	if err != nil {
+		return 0
+	}
+	builder := strings.Builder{}
+	encoder := NewEncoder(&builder)
+	err = encoder.Encode(result)
+	if err != nil {
+		return 0
+	}
+	return 1
+}
+
+func FuzzStream(input []byte) int {
+	var stream *unmarshalStream
+	decoder := Stream.NewDecoder(bytes.NewReader(input))
+	defer decoder.Release()
+	done := decoder.Done()
+	for {
+		err := decoder.DecodeStream(stream)
+		if err != nil {
+			return 0
+		}
+		select {
+		case <-done:
+			return 1
+		default:
+		}
+	}
+}
+
+type unmarshalTarget struct{}
+
+func (*unmarshalTarget) UnmarshalJSONObject(dec *Decoder, key string) error {
+	return nil
+}
+
+func (*unmarshalTarget) NKeys() int {
+	return 0
+}
+
+type unmarshalStream struct{}
+
+func (*unmarshalStream) UnmarshalStream(decoder *StreamDecoder) error {
+	var result *interface{}
+	return decoder.Decode(result)
+}


### PR DESCRIPTION
Hi guys. What would you think about integrating continuous fuzzing? Fuzzit gives free service for open source projects.

This patch fuzzes unmarshaling, decoding, and stream decoding.

Setup is like this:
* In [Fuzzit](https://fuzzit.dev/) create targets `gojay-unmarshal` `gojay-decode` `gojay-stream`.
* In Fuzzit settings grab an API key. On the repo settings in [Travis](https://travis-ci.org/) paste it to the envvar `FUZZIT_API_KEY`.

The build will fail due to the missing API key. I've run successful tests locally. If you decide to go for it getting the API key in should fix that. So far it's found no crashes. It seems to be in good shape.

Thank you for considering.