### PR TITLE
Fix/unable to decode negative zero int

### DIFF
--- a/decode_number_float_test.go
+++ b/decode_number_float_test.go
@@ -170,6 +170,11 @@ func TestDecoderFloat64(t *testing.T) {
 			expectedResult: -0.000082,
 		},
 		{
+			name:           "basic-float-negative-zero",
+			json:           "-0.0",
+			expectedResult: 0.0,
+		},
+		{
 			name:           "basic-float",
 			json:           "2.4595",
 			expectedResult: 2.4595,

--- a/decode_number_int.go
+++ b/decode_number_int.go
@@ -902,7 +902,7 @@ func (dec *Decoder) getInt64Negative() (int64, error) {
 	// look for following numbers
 	for ; dec.cursor < dec.length || dec.read(); dec.cursor++ {
 		switch dec.data[dec.cursor] {
-		case '1', '2', '3', '4', '5', '6', '7', '8', '9':
+		case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
 			return dec.getInt64()
 		default:
 			return 0, dec.raiseInvalidJSONErr(dec.cursor)

--- a/decode_number_int_test.go
+++ b/decode_number_int_test.go
@@ -28,6 +28,11 @@ func TestDecoderInt(t *testing.T) {
 			expectedResult: 1039405,
 		},
 		{
+			name:           "basic-negative-zero",
+			json:           "-0",
+			expectedResult: 0,
+		},
+		{
 			name:           "basic-negative",
 			json:           "-2",
 			expectedResult: -2,


### PR DESCRIPTION
## Why
Currently this is unable to decode json with value `-0`(it throws error). However, `{"key": -0}` should be a valid JSON and gojay should be able to decode it.

## What is changed
- Found that `float` decoder allows to decode `{"key": -0.0}`. So I have change the `getInt64Negative` that it also allow to accept `0` 
- add `-0` test case for `decode_number_int`
- add `-0.0` test case for `decode_number_float`