### PR TITLE
EncodeBuilder: Correcting which type of controls should be written in a JSON string

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,32 @@
+name: Go
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+    
+jobs:
+
+  test:
+    
+    name: Running Go Tests
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Go 1.12
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.12
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v1
+    
+#    - name: Configure git for private modules
+#      env:
+#        TOKEN: ${{ secrets.TOKEN }}
+#      run: git config --global url."https://YOUR_GITHUB_USERNAME:${TOKEN}@github.com".insteadOf "https://github.com"
+
+    - name: Run Test
+      run: go test ./... -race -cover -v -short

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ vendor
 *.log
 *.test
 .vscode
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor
 *.test
 .vscode
 .idea
+.DS_Store

--- a/decode_bool.go
+++ b/decode_bool.go
@@ -114,7 +114,7 @@ func (dec *Decoder) assertTrue() error {
 			}
 		case 3:
 			switch dec.data[dec.cursor] {
-			case ' ', '\b', '\t', '\n', ',', ']', '}':
+			case ' ', '\b', '\t', '\n', '\r', ',', ']', '}':
 				// dec.cursor--
 				return nil
 			default:
@@ -147,7 +147,7 @@ func (dec *Decoder) assertNull() error {
 			}
 		case 3:
 			switch dec.data[dec.cursor] {
-			case ' ', '\t', '\n', ',', ']', '}':
+			case ' ', '\t', '\n', '\r', ',', ']', '}':
 				// dec.cursor--
 				return nil
 			default:
@@ -184,7 +184,7 @@ func (dec *Decoder) assertFalse() error {
 			}
 		case 4:
 			switch dec.data[dec.cursor] {
-			case ' ', '\t', '\n', ',', ']', '}':
+			case ' ', '\t', '\n', '\r', ',', ']', '}':
 				// dec.cursor--
 				return nil
 			default:

--- a/decode_number_int.go
+++ b/decode_number_int.go
@@ -275,7 +275,7 @@ func (dec *Decoder) getInt16() (int16, error) {
 					}
 					val := floatVal * float64(pow10uint64[pExp])
 					return int16(val), nil
-				case ' ', '\t', '\n', ',', ']', '}':
+				case ' ', '\t', '\n', '\r', ',', ']', '}':
 					dec.cursor = j
 					return dec.atoi16(start, end), nil
 				default:
@@ -507,7 +507,7 @@ func (dec *Decoder) getInt8() (int8, error) {
 					}
 					val := floatVal * float64(pow10uint64[pExp])
 					return int8(val), nil
-				case ' ', '\t', '\n', ',', ']', '}':
+				case ' ', '\t', '\n', '\r', ',', ']', '}':
 					dec.cursor = j
 					return dec.atoi8(start, end), nil
 				default:
@@ -548,7 +548,7 @@ func (dec *Decoder) getInt8WithExp(init int8) (int8, error) {
 				case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
 					uintv := uint8(digits[dec.data[dec.cursor]])
 					exp = (exp << 3) + (exp << 1) + uintv
-				case ' ', '\t', '\n', '}', ',', ']':
+				case ' ', '\t', '\n', '\r', '}', ',', ']':
 					if exp+1 >= uint8(len(pow10uint64)) {
 						return 0, dec.raiseInvalidJSONErr(dec.cursor)
 					}
@@ -737,7 +737,7 @@ func (dec *Decoder) getInt32() (int32, error) {
 					}
 					val := floatVal * float64(pow10uint64[pExp])
 					return int32(val), nil
-				case ' ', '\t', '\n', ',', ']', '}':
+				case ' ', '\t', '\n', '\r', ',', ']', '}':
 					dec.cursor = j
 					return dec.atoi32(start, end), nil
 				default:
@@ -778,7 +778,7 @@ func (dec *Decoder) getInt32WithExp(init int32) (int32, error) {
 				case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
 					uintv := uint32(digits[dec.data[dec.cursor]])
 					exp = (exp << 3) + (exp << 1) + uintv
-				case ' ', '\t', '\n', '}', ',', ']':
+				case ' ', '\t', '\n', '\r', '}', ',', ']':
 					if exp+1 >= uint32(len(pow10uint64)) {
 						return 0, dec.raiseInvalidJSONErr(dec.cursor)
 					}
@@ -920,7 +920,7 @@ func (dec *Decoder) getInt64() (int64, error) {
 		case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
 			end = j
 			continue
-		case ' ', '\t', '\n', ',', '}', ']':
+		case ' ', '\t', '\n', '\r', ',', '}', ']':
 			dec.cursor = j
 			return dec.atoi64(start, end), nil
 		case '.':
@@ -971,7 +971,7 @@ func (dec *Decoder) getInt64() (int64, error) {
 					}
 					val := floatVal * float64(pow10uint64[pExp])
 					return int64(val), nil
-				case ' ', '\t', '\n', ',', ']', '}':
+				case ' ', '\t', '\n', '\r', ',', ']', '}':
 					dec.cursor = j
 					return dec.atoi64(start, end), nil
 				default:
@@ -1009,7 +1009,7 @@ func (dec *Decoder) getInt64WithExp(init int64) (int64, error) {
 				case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
 					uintv := uint64(digits[dec.data[dec.cursor]])
 					exp = (exp << 3) + (exp << 1) + uintv
-				case ' ', '\t', '\n', '}', ',', ']':
+				case ' ', '\t', '\n', '\r', '}', ',', ']':
 					if exp+1 >= uint64(len(pow10uint64)) {
 						return 0, dec.raiseInvalidJSONErr(dec.cursor)
 					}

--- a/decode_token.go
+++ b/decode_token.go
@@ -1,0 +1,34 @@
+package gojay
+
+type Token uint8
+
+const (
+	TokenUnknown Token = iota
+	TokenArray
+	TokenBoolean
+	TokenNull
+	TokenNumber
+	TokenObject
+	TokenString
+)
+
+// NextToken returns a token identifying whats next in the underline data buffer as a token e.g string (") array ([)
+// should only be used in the context of satisfying the UnmarshalJSONObject interface
+func (dec *Decoder) NextToken() Token {
+	switch b := dec.nextChar(); {
+	case b == '[':
+		return TokenArray
+	case b == 't', b == 'f':
+		return TokenBoolean
+	case b == 'n':
+		return TokenNull
+	case rune(b) >= 0x30 && rune(b) <= 0x39:
+		return TokenNumber
+	case b == '{':
+		return TokenObject
+	case b == '"':
+		return TokenString
+	default:
+		return TokenUnknown
+	}
+}

--- a/decode_token_test.go
+++ b/decode_token_test.go
@@ -1,0 +1,270 @@
+package gojay
+
+import (
+	"encoding/json"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestDecoder_NextToken(t *testing.T) {
+	type args struct {
+		json string
+	}
+	testCases := []struct {
+		name string
+		args args
+		want Token
+	}{
+		{
+			name: "should determine that a slice is next in the buffer",
+			args: args{
+				json: `[`,
+			},
+			want: TokenArray,
+		},
+		{
+			name: "should determine that a string is next in the buffer the implementation should convert to a slice",
+			args: args{
+				json: `"`,
+			},
+			want: TokenString,
+		},
+		{
+			name: "should determine that a numeric is next in the buffer",
+			args: args{
+				json: `{`,
+			},
+			want: TokenObject,
+		},
+		{
+			name: "should determine that a numeric is next in the buffer",
+			args: args{
+				json: `0`,
+			},
+			want: TokenNumber,
+		},
+		{
+			name: "should determine that a numeric is next in the buffer",
+			args: args{
+				json: `1`,
+			},
+			want: TokenNumber,
+		},
+		{
+			name: "should determine that a numeric is next in the buffer",
+			args: args{
+				json: `9`,
+			},
+			want: TokenNumber,
+		},
+		{
+			name: "should determine that a numeric is next in the buffer",
+			args: args{
+				json: `39`,
+			},
+			want: TokenNumber,
+		},
+		{
+			name: "should determine that a boolean is next in the buffer",
+			args: args{
+				json: `true`,
+			},
+			want: TokenBoolean,
+		},
+		{
+			name: "should determine that a boolean is next in the buffer",
+			args: args{
+				json: `false`,
+			},
+			want: TokenBoolean,
+		},
+		{
+			name: "should determine that a null is next in the buffer",
+			args: args{
+				json: `null`,
+			},
+			want: TokenNull,
+		},
+		{
+			name: "should not be able to determine the token",
+			args: args{
+				json: `z`,
+			},
+			want: TokenUnknown,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			dec := BorrowDecoder(strings.NewReader(tt.args.json))
+			if got := dec.NextToken(); got != tt.want {
+				t.Fatalf("NextToken() got %v wanted %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDecoder_NextToken_UnmarshalJSONObject(t *testing.T) {
+	type args struct {
+		json string
+	}
+	testCases := []struct {
+		name string
+		args args
+		want sliceTestObjectWithToken
+	}{
+		{
+			name: "should determine that a slice is next in the buffer",
+			args: args{
+				json: `{"sliceString": ["zip", "zap"]}`,
+			},
+			want: sliceTestObjectWithToken{
+				SliceString: []string{"zip", "zap"},
+			},
+		},
+		{
+			name: "should determine that a string is next in the buffer the implementation should convert to a slice",
+			args: args{
+				json: `{"sliceString": "zip,zap"}`,
+			},
+			want: sliceTestObjectWithToken{
+				SliceString: []string{"zip", "zap"},
+			},
+		},
+		{
+			name: "should determine that a numeric is next in the buffer the implementation should convert to a slice",
+			args: args{
+				json: `{"sliceString": 10}`,
+			},
+			want: sliceTestObjectWithToken{
+				SliceString: []string{"10"},
+			},
+		},
+		{
+			name: "should determine that an object is next in the buffer the implementation should convert to a slice",
+			args: args{
+				json: `{"sliceString": {"zip": "zap"}}`,
+			},
+			want: sliceTestObjectWithToken{
+				SliceString: []string{"zip", "zap"},
+			},
+		},
+		{
+			name: "should determine that a boolean is next in the buffer the implementation should convert to a slice",
+			args: args{
+				json: `{"sliceString": true}`,
+			},
+			want: sliceTestObjectWithToken{
+				SliceString: []string{"true"},
+			},
+		},
+		{
+			name: "should determine that null is next in the buffer the implementation should convert to a slice",
+			args: args{
+				json: `{"sliceString": null}`,
+			},
+			want: sliceTestObjectWithToken{
+				SliceString: []string{},
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			dec := BorrowDecoder(strings.NewReader(tt.args.json))
+
+			var got sliceTestObjectWithToken
+			err := dec.Decode(&got)
+			if err != nil {
+				t.Fatalf("Decode() err %v", err)
+			}
+
+			sort.Strings(got.SliceString)
+			sort.Strings(tt.want.SliceString)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("NextToken_UnmarshalJSONObject() got %+v wanted %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+type sliceTestObjectWithToken struct {
+	SliceString []string
+}
+
+type testSlice []string
+
+// UnmarshalJSONArray decodes JSON array elements into slice
+func (ts *testSlice) UnmarshalJSONArray(dec *Decoder) error {
+	var value string
+	if err := dec.String(&value); err != nil {
+		return err
+	}
+	*ts = append(*ts, value)
+	return nil
+}
+
+func (s *sliceTestObjectWithToken) UnmarshalJSONObject(dec *Decoder, k string) error {
+	switch k {
+	case "sliceString":
+		switch dec.NextToken() {
+		case TokenArray:
+			var aSlice testSlice
+			err := dec.Array(&aSlice)
+			if err != nil {
+				return err
+			}
+
+			s.SliceString = aSlice
+		case TokenString:
+			var ss string
+			err := dec.String(&ss)
+			if err != nil {
+				return err
+			}
+			arrSlice := strings.Split(ss, ",")
+			s.SliceString = arrSlice
+		case TokenNumber:
+			var n int
+			err := dec.Int(&n)
+			if err != nil {
+				return err
+			}
+			s.SliceString = []string{strconv.Itoa(n)}
+		case TokenObject:
+			eb := make(EmbeddedJSON, 0, 128)
+			if err := dec.EmbeddedJSON(&eb); err != nil {
+				return err
+			}
+
+			obj := make(map[string]string)
+			err := json.Unmarshal(eb, &obj)
+			if err != nil {
+				return err
+			}
+
+			var arrSlice []string
+			for key, value := range obj {
+				arrSlice = append(arrSlice, key, value)
+			}
+			s.SliceString = arrSlice
+		case TokenBoolean:
+			var n bool
+			err := dec.Bool(&n)
+			if err != nil {
+				return err
+			}
+			s.SliceString = []string{strconv.FormatBool(n)}
+		case TokenNull:
+			s.SliceString = []string{}
+		}
+	}
+	return nil
+}
+
+func (s *sliceTestObjectWithToken) NKeys() int {
+	return 0
+}

--- a/encode_builder.go
+++ b/encode_builder.go
@@ -1,7 +1,5 @@
 package gojay
 
-const hex = "0123456789abcdef"
-
 // grow grows b's capacity, if necessary, to guarantee space for
 // another n bytes. After grow(n), at least n bytes can be written to b
 // without another allocation. If n is negative, grow panics.
@@ -36,13 +34,13 @@ func (enc *Encoder) writeString(s string) {
 }
 
 func (enc *Encoder) writeStringEscape(s string) {
-	l := len(s)
-	for i := 0; i < l; i++ {
+	for i := 0; i < len(s); i++ {
 		c := s[i]
 		if c >= 0x20 && c != '\\' && c != '"' {
 			enc.writeByte(c)
 			continue
 		}
+
 		switch c {
 		case '\\', '"':
 			enc.writeTwoBytes('\\', c)
@@ -56,10 +54,6 @@ func (enc *Encoder) writeStringEscape(s string) {
 			enc.writeTwoBytes('\\', 'r')
 		case '\t':
 			enc.writeTwoBytes('\\', 't')
-		default:
-			enc.writeString(`\u00`)
-			enc.writeTwoBytes(hex[c>>4], hex[c&0xF])
 		}
-		continue
 	}
 }

--- a/encode_builder_test.go
+++ b/encode_builder_test.go
@@ -1,1 +1,80 @@
 package gojay
+
+import (
+	"bytes"
+	"testing"
+)
+
+// https://www.ascii-code.com/
+func Test_writeStringEscape(t *testing.T) {
+	type args struct {
+		stringAsByte int
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "should not write a null byte to a string",
+			args: args{
+				stringAsByte: 0,
+			},
+			want: "",
+		},
+		{
+			name: "should not write a bell byte to a string",
+			args: args{
+				stringAsByte: 7,
+			},
+			want: "",
+		},
+		{
+			name: "should not write a vertical tab byte to a string",
+			args: args{
+				stringAsByte: 11,
+			},
+			want: "",
+		},
+		{
+			name: "should not write a shift in byte to a string",
+			args: args{
+				stringAsByte: 15,
+			},
+			want: "",
+		},
+		{
+			name: "should not write an escape byte to a string",
+			args: args{
+				stringAsByte: 27,
+			},
+			want: "",
+		},
+		{
+			name: "should write a horizontal tab byte to a string",
+			args: args{
+				stringAsByte: 9,
+			},
+			want: "\\t",
+		},
+		{
+			name: "should write an at byte to a string",
+			args: args{
+				stringAsByte: 64,
+			},
+			want: "@",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := new(bytes.Buffer)
+			e := NewEncoder(b)
+			e.writeStringEscape(string(rune(tt.args.stringAsByte)))
+			got := string(e.buf)
+			if got != tt.want {
+				t.Fatalf("writeStringEscape() got %s want %s", got, tt.want)
+			}
+		})
+	}
+}

--- a/encode_builder_test.go
+++ b/encode_builder_test.go
@@ -1,1 +1,117 @@
 package gojay
+
+import (
+	"bytes"
+	"testing"
+)
+
+// https://www.ascii-code.com/
+func Test_writeStringEscape(t *testing.T) {
+	type args struct {
+		stringAsByte int
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "should not write a null byte to a string",
+			args: args{
+				stringAsByte: 0,
+			},
+			want: "",
+		},
+		{
+			name: "should not write a bell byte to a string",
+			args: args{
+				stringAsByte: 7,
+			},
+			want: "",
+		},
+		{
+			name: "should not write a vertical tab byte to a string",
+			args: args{
+				stringAsByte: 11,
+			},
+			want: "",
+		},
+		{
+			name: "should not write a shift in byte to a string",
+			args: args{
+				stringAsByte: 15,
+			},
+			want: "",
+		},
+		{
+			name: "should write a horizontal tab byte to a string",
+			args: args{
+				stringAsByte: 9,
+			},
+			want: "\\t",
+		},
+		{
+			name: "should write an escape byte to a string",
+			args: args{
+				stringAsByte: 27,
+			},
+			want: "\\u001b",
+		},
+		{
+			name: "should write an at byte to a string",
+			args: args{
+				stringAsByte: 64,
+			},
+			want: "@",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := new(bytes.Buffer)
+			e := NewEncoder(b)
+			e.writeStringEscape(string(rune(tt.args.stringAsByte)))
+			got := string(e.buf)
+			if got != tt.want {
+				t.Fatalf("writeStringEscape() got %s want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+var _StopCompilerOptimizationBool bool
+
+func Benchmark_isABlackListedControlAcceptable(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		x := isABlackListedControl(64)
+		_StopCompilerOptimizationBool = x
+	}
+}
+
+func Benchmark_isABlackListedControlBell(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		x := isABlackListedControl(7)
+		_StopCompilerOptimizationBool = x
+	}
+}
+
+func Benchmark_isABlackListedControlVertical(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		x := isABlackListedControl(11)
+		_StopCompilerOptimizationBool = x
+	}
+}
+
+func Benchmark_isABlackListedControlEscape(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		x := isABlackListedControl(27)
+		_StopCompilerOptimizationBool = x
+	}
+}
+
+func Benchmark_isABlackListedControlShift(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		x := isABlackListedControl(15)
+		_StopCompilerOptimizationBool = x
+	}
+}

--- a/encode_string_test.go
+++ b/encode_string_test.go
@@ -92,18 +92,6 @@ func TestEncoderStringEncodeAPI(t *testing.T) {
 			builder.String(),
 			"Result of marshalling is different as the one expected")
 	})
-	t.Run("escaped-control-char", func(t *testing.T) {
-		str := "\u001b"
-		builder := &strings.Builder{}
-		enc := NewEncoder(builder)
-		err := enc.EncodeString(str)
-		assert.Nil(t, err, "Error should be nil")
-		assert.Equal(
-			t,
-			`"\u001b"`,
-			builder.String(),
-			"Result of marshalling is different as the one expected")
-	})
 	t.Run("escaped-sequence3", func(t *testing.T) {
 		str := "hello \f world 𝄞"
 		builder := &strings.Builder{}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/francoispqt/gojay
+module github.com/marcsantiago/gojay
 
 go 1.12
 


### PR DESCRIPTION
According to the JSON spec these are the only valid and considered controls for JSON

\b  Backspace (ascii code 08)
\f  Form feed (ascii code 0C)
\n  New line
\r  Carriage return
\t  Tab
\"  Double quote
\\  Backslash character
https://www.json.org/json-en.html

fixes https://github.com/francoispqt/gojay/issues/145