### PR TITLE
Fix interface decoding when string has escape sequence

### DIFF
--- a/decode_interface.go
+++ b/decode_interface.go
@@ -87,7 +87,7 @@ func (dec *Decoder) getObject() (start int, end int, err error) {
 		case '"':
 			start = dec.cursor
 			dec.cursor++
-			start, end, err = dec.getString()
+			start, end, err = dec.getString(true)
 			start--
 			dec.cursor = end
 			return

--- a/decode_interface_test.go
+++ b/decode_interface_test.go
@@ -123,6 +123,13 @@ func TestDecodeInterfaceBasic(t *testing.T) {
 			errType:         InvalidJSONError(""),
 			skipCheckResult: true,
 		},
+		{
+			name:           "escaped-string",
+			json:           `"\"hola amigos!"`,
+			expectedResult: interface{}("\"hola amigos!"),
+			err:            false,
+		},
+
 	}
 
 	for _, testCase := range testCases {

--- a/decode_object.go
+++ b/decode_object.go
@@ -258,7 +258,7 @@ func (dec *Decoder) nextKey() (string, bool, error) {
 			continue
 		case '"':
 			dec.cursor = dec.cursor + 1
-			start, end, err := dec.getString()
+			start, end, err := dec.getString(false)
 			if err != nil {
 				return "", false, err
 			}


### PR DESCRIPTION
Decoding of a string using the interface API fails when a string has an escape
sequence. Go's native JSON decoding function is called in such a case, and it
expects to get the original string. Provide the raw string to prevent the
failures that are currently caused.

Adding a test for this specific scenario.