### PR TITLE
prevent from panic encoding scalar types 

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -196,7 +196,12 @@ func (enc *Encoder) Write() (int, error) {
 	return i, err
 }
 
-func (enc *Encoder) getPreviousRune() byte {
+// getPreviousRune returns false when the buffer is empty.
+func (enc *Encoder) getPreviousRune() (byte, bool) {
 	last := len(enc.buf) - 1
-	return enc.buf[last]
+	if last < 0 {
+		return ' ', false
+	}
+
+	return enc.buf[last], true
 }

--- a/encode_array.go
+++ b/encode_array.go
@@ -62,8 +62,8 @@ func (enc *Encoder) AddArrayKeyNullEmpty(key string, v MarshalerJSONArray) {
 func (enc *Encoder) Array(v MarshalerJSONArray) {
 	if v.IsNil() {
 		enc.grow(3)
-		r := enc.getPreviousRune()
-		if r != '[' {
+		r, ok := enc.getPreviousRune()
+		if ok && r != '[' {
 			enc.writeByte(',')
 		}
 		enc.writeByte('[')
@@ -71,8 +71,8 @@ func (enc *Encoder) Array(v MarshalerJSONArray) {
 		return
 	}
 	enc.grow(100)
-	r := enc.getPreviousRune()
-	if r != '[' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '[' {
 		enc.writeByte(',')
 	}
 	enc.writeByte('[')
@@ -87,8 +87,8 @@ func (enc *Encoder) ArrayOmitEmpty(v MarshalerJSONArray) {
 		return
 	}
 	enc.grow(4)
-	r := enc.getPreviousRune()
-	if r != '[' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '[' {
 		enc.writeByte(',')
 	}
 	enc.writeByte('[')
@@ -100,8 +100,8 @@ func (enc *Encoder) ArrayOmitEmpty(v MarshalerJSONArray) {
 // value must implement Marshaler
 func (enc *Encoder) ArrayNullEmpty(v MarshalerJSONArray) {
 	enc.grow(4)
-	r := enc.getPreviousRune()
-	if r != '[' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '[' {
 		enc.writeByte(',')
 	}
 	if v.IsNil() {
@@ -123,8 +123,8 @@ func (enc *Encoder) ArrayKey(key string, v MarshalerJSONArray) {
 	}
 	if v.IsNil() {
 		enc.grow(2 + len(key))
-		r := enc.getPreviousRune()
-		if r != '{' {
+		r, ok := enc.getPreviousRune()
+		if ok && r != '{' {
 			enc.writeByte(',')
 		}
 		enc.writeByte('"')
@@ -134,8 +134,8 @@ func (enc *Encoder) ArrayKey(key string, v MarshalerJSONArray) {
 		return
 	}
 	enc.grow(5 + len(key))
-	r := enc.getPreviousRune()
-	if r != '{' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '{' {
 		enc.writeByte(',')
 	}
 	enc.writeByte('"')
@@ -157,8 +157,8 @@ func (enc *Encoder) ArrayKeyOmitEmpty(key string, v MarshalerJSONArray) {
 		return
 	}
 	enc.grow(5 + len(key))
-	r := enc.getPreviousRune()
-	if r != '{' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '{' {
 		enc.writeByte(',')
 	}
 	enc.writeByte('"')
@@ -177,8 +177,8 @@ func (enc *Encoder) ArrayKeyNullEmpty(key string, v MarshalerJSONArray) {
 		}
 	}
 	enc.grow(5 + len(key))
-	r := enc.getPreviousRune()
-	if r != '{' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '{' {
 		enc.writeByte(',')
 	}
 	if v.IsNil() {

--- a/encode_bool.go
+++ b/encode_bool.go
@@ -62,8 +62,8 @@ func (enc *Encoder) AddBoolKeyNullEmpty(key string, v bool) {
 // Bool adds a bool to be encoded, must be used inside a slice or array encoding (does not encode a key)
 func (enc *Encoder) Bool(v bool) {
 	enc.grow(5)
-	r := enc.getPreviousRune()
-	if r != '[' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '[' {
 		enc.writeByte(',')
 	}
 	if v {
@@ -79,8 +79,8 @@ func (enc *Encoder) BoolOmitEmpty(v bool) {
 		return
 	}
 	enc.grow(5)
-	r := enc.getPreviousRune()
-	if r != '[' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '[' {
 		enc.writeByte(',')
 	}
 	enc.writeString("true")
@@ -89,8 +89,8 @@ func (enc *Encoder) BoolOmitEmpty(v bool) {
 // BoolNullEmpty adds a bool to be encoded, must be used inside a slice or array encoding (does not encode a key)
 func (enc *Encoder) BoolNullEmpty(v bool) {
 	enc.grow(5)
-	r := enc.getPreviousRune()
-	if r != '[' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '[' {
 		enc.writeByte(',')
 	}
 	if v == false {
@@ -108,8 +108,8 @@ func (enc *Encoder) BoolKey(key string, value bool) {
 		}
 	}
 	enc.grow(5 + len(key))
-	r := enc.getPreviousRune()
-	if r != '{' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '{' {
 		enc.writeByte(',')
 	}
 	enc.writeByte('"')
@@ -130,8 +130,8 @@ func (enc *Encoder) BoolKeyOmitEmpty(key string, v bool) {
 		return
 	}
 	enc.grow(5 + len(key))
-	r := enc.getPreviousRune()
-	if r != '{' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '{' {
 		enc.writeByte(',')
 	}
 	enc.writeByte('"')
@@ -149,8 +149,8 @@ func (enc *Encoder) BoolKeyNullEmpty(key string, v bool) {
 		}
 	}
 	enc.grow(5 + len(key))
-	r := enc.getPreviousRune()
-	if r != '{' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '{' {
 		enc.writeByte(',')
 	}
 	enc.writeByte('"')

--- a/encode_embedded_json.go
+++ b/encode_embedded_json.go
@@ -25,8 +25,8 @@ func (enc *Encoder) encodeEmbeddedJSON(v *EmbeddedJSON) ([]byte, error) {
 // it expects the JSON to be of proper format.
 func (enc *Encoder) AddEmbeddedJSON(v *EmbeddedJSON) {
 	enc.grow(len(*v) + 4)
-	r := enc.getPreviousRune()
-	if r != '[' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '[' {
 		enc.writeByte(',')
 	}
 	enc.writeBytes(*v)
@@ -40,8 +40,8 @@ func (enc *Encoder) AddEmbeddedJSONOmitEmpty(v *EmbeddedJSON) {
 	if v == nil || len(*v) == 0 {
 		return
 	}
-	r := enc.getPreviousRune()
-	if r != '[' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '[' {
 		enc.writeByte(',')
 	}
 	enc.writeBytes(*v)
@@ -58,8 +58,8 @@ func (enc *Encoder) AddEmbeddedJSONKey(key string, v *EmbeddedJSON) {
 		}
 	}
 	enc.grow(len(key) + len(*v) + 5)
-	r := enc.getPreviousRune()
-	if r != '{' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '{' {
 		enc.writeByte(',')
 	}
 	enc.writeByte('"')
@@ -82,8 +82,8 @@ func (enc *Encoder) AddEmbeddedJSONKeyOmitEmpty(key string, v *EmbeddedJSON) {
 		return
 	}
 	enc.grow(len(key) + len(*v) + 5)
-	r := enc.getPreviousRune()
-	if r != '{' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '{' {
 		enc.writeByte(',')
 	}
 	enc.writeByte('"')

--- a/encode_null.go
+++ b/encode_null.go
@@ -8,8 +8,8 @@ func (enc *Encoder) AddNull() {
 // Null adds a `null` to be encoded. Must be used while encoding an array.`
 func (enc *Encoder) Null() {
 	enc.grow(5)
-	r := enc.getPreviousRune()
-	if r != '[' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '[' {
 		enc.writeByte(',')
 	}
 	enc.writeBytes(nullBytes)
@@ -28,8 +28,8 @@ func (enc *Encoder) NullKey(key string) {
 		}
 	}
 	enc.grow(5 + len(key))
-	r := enc.getPreviousRune()
-	if r != '{' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '{' {
 		enc.writeByte(',')
 	}
 	enc.writeByte('"')

--- a/encode_null_test.go
+++ b/encode_null_test.go
@@ -14,6 +14,11 @@ func TestEncodeNull(t *testing.T) {
 		expectedJSON string
 	}{
 		{
+			name:         "encode null",
+			baseJSON:     ``,
+			expectedJSON: `null,null`,
+		},
+		{
 			name:         "basic 1st element",
 			baseJSON:     `[`,
 			expectedJSON: `[null,null`,
@@ -44,6 +49,11 @@ func TestEncodeNullKey(t *testing.T) {
 		baseJSON     string
 		expectedJSON string
 	}{
+		{
+			name:         "encode null",
+			baseJSON:     ``,
+			expectedJSON: `"foo":null,"bar":null`,
+		},
 		{
 			name:         "basic 1st element",
 			baseJSON:     `{`,

--- a/encode_number_float.go
+++ b/encode_number_float.go
@@ -121,8 +121,8 @@ func (enc *Encoder) AddFloat64OmitEmpty(v float64) {
 // Float64 adds a float64 to be encoded, must be used inside a slice or array encoding (does not encode a key)
 func (enc *Encoder) Float64(v float64) {
 	enc.grow(10)
-	r := enc.getPreviousRune()
-	if r != '[' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '[' {
 		enc.writeByte(',')
 	}
 	enc.buf = strconv.AppendFloat(enc.buf, v, 'f', -1, 64)
@@ -135,8 +135,8 @@ func (enc *Encoder) Float64OmitEmpty(v float64) {
 		return
 	}
 	enc.grow(10)
-	r := enc.getPreviousRune()
-	if r != '[' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '[' {
 		enc.writeByte(',')
 	}
 	enc.buf = strconv.AppendFloat(enc.buf, v, 'f', -1, 64)
@@ -146,8 +146,8 @@ func (enc *Encoder) Float64OmitEmpty(v float64) {
 // must be used inside a slice or array encoding (does not encode a key).
 func (enc *Encoder) Float64NullEmpty(v float64) {
 	enc.grow(10)
-	r := enc.getPreviousRune()
-	if r != '[' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '[' {
 		enc.writeByte(',')
 	}
 	if v == 0 {
@@ -175,8 +175,8 @@ func (enc *Encoder) Float64Key(key string, value float64) {
 			return
 		}
 	}
-	r := enc.getPreviousRune()
-	if r != '{' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '{' {
 		enc.writeByte(',')
 	}
 	enc.grow(10)
@@ -198,8 +198,8 @@ func (enc *Encoder) Float64KeyOmitEmpty(key string, v float64) {
 		return
 	}
 	enc.grow(10 + len(key))
-	r := enc.getPreviousRune()
-	if r != '{' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '{' {
 		enc.writeByte(',')
 	}
 	enc.writeByte('"')
@@ -217,8 +217,8 @@ func (enc *Encoder) Float64KeyNullEmpty(key string, v float64) {
 		}
 	}
 	enc.grow(10 + len(key))
-	r := enc.getPreviousRune()
-	if r != '{' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '{' {
 		enc.writeByte(',')
 	}
 	enc.writeByte('"')
@@ -250,8 +250,8 @@ func (enc *Encoder) AddFloat32NullEmpty(v float32) {
 
 // Float32 adds a float32 to be encoded, must be used inside a slice or array encoding (does not encode a key)
 func (enc *Encoder) Float32(v float32) {
-	r := enc.getPreviousRune()
-	if r != '[' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '[' {
 		enc.writeByte(',')
 	}
 	enc.buf = strconv.AppendFloat(enc.buf, float64(v), 'f', -1, 32)
@@ -264,8 +264,8 @@ func (enc *Encoder) Float32OmitEmpty(v float32) {
 		return
 	}
 	enc.grow(10)
-	r := enc.getPreviousRune()
-	if r != '[' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '[' {
 		enc.writeByte(',')
 	}
 	enc.buf = strconv.AppendFloat(enc.buf, float64(v), 'f', -1, 32)
@@ -275,8 +275,8 @@ func (enc *Encoder) Float32OmitEmpty(v float32) {
 // must be used inside a slice or array encoding (does not encode a key).
 func (enc *Encoder) Float32NullEmpty(v float32) {
 	enc.grow(10)
-	r := enc.getPreviousRune()
-	if r != '[' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '[' {
 		enc.writeByte(',')
 	}
 	if v == 0 {
@@ -311,8 +311,8 @@ func (enc *Encoder) Float32Key(key string, v float32) {
 		}
 	}
 	enc.grow(10 + len(key))
-	r := enc.getPreviousRune()
-	if r != '{' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '{' {
 		enc.writeByte(',')
 	}
 	enc.writeByte('"')
@@ -334,8 +334,8 @@ func (enc *Encoder) Float32KeyOmitEmpty(key string, v float32) {
 		return
 	}
 	enc.grow(10 + len(key))
-	r := enc.getPreviousRune()
-	if r != '{' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '{' {
 		enc.writeByte(',')
 	}
 	enc.writeByte('"')
@@ -353,8 +353,8 @@ func (enc *Encoder) Float32KeyNullEmpty(key string, v float32) {
 		}
 	}
 	enc.grow(10 + len(key))
-	r := enc.getPreviousRune()
-	if r != '{' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '{' {
 		enc.writeByte(',')
 	}
 	enc.writeByte('"')

--- a/encode_number_int.go
+++ b/encode_number_int.go
@@ -60,8 +60,8 @@ func (enc *Encoder) AddIntNullEmpty(v int) {
 // Int adds an int to be encoded, must be used inside a slice or array encoding (does not encode a key)
 func (enc *Encoder) Int(v int) {
 	enc.grow(10)
-	r := enc.getPreviousRune()
-	if r != '[' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '[' {
 		enc.writeByte(',')
 	}
 	enc.buf = strconv.AppendInt(enc.buf, int64(v), 10)
@@ -74,8 +74,8 @@ func (enc *Encoder) IntOmitEmpty(v int) {
 		return
 	}
 	enc.grow(10)
-	r := enc.getPreviousRune()
-	if r != '[' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '[' {
 		enc.writeByte(',')
 	}
 	enc.buf = strconv.AppendInt(enc.buf, int64(v), 10)
@@ -85,8 +85,8 @@ func (enc *Encoder) IntOmitEmpty(v int) {
 // must be used inside a slice or array encoding (does not encode a key).
 func (enc *Encoder) IntNullEmpty(v int) {
 	enc.grow(10)
-	r := enc.getPreviousRune()
-	if r != '[' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '[' {
 		enc.writeByte(',')
 	}
 	if v == 0 {
@@ -121,8 +121,8 @@ func (enc *Encoder) IntKey(key string, v int) {
 		}
 	}
 	enc.grow(10 + len(key))
-	r := enc.getPreviousRune()
-	if r != '{' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '{' {
 		enc.writeByte(',')
 	}
 	enc.writeByte('"')
@@ -143,8 +143,8 @@ func (enc *Encoder) IntKeyOmitEmpty(key string, v int) {
 		return
 	}
 	enc.grow(10 + len(key))
-	r := enc.getPreviousRune()
-	if r != '{' && r != '[' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '{' && r != '[' {
 		enc.writeByte(',')
 	}
 	enc.writeByte('"')
@@ -162,8 +162,8 @@ func (enc *Encoder) IntKeyNullEmpty(key string, v int) {
 		}
 	}
 	enc.grow(10 + len(key))
-	r := enc.getPreviousRune()
-	if r != '{' && r != '[' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '{' && r != '[' {
 		enc.writeByte(',')
 	}
 	enc.writeByte('"')
@@ -196,8 +196,8 @@ func (enc *Encoder) AddInt64NullEmpty(v int64) {
 // Int64 adds an int to be encoded, must be used inside a slice or array encoding (does not encode a key)
 func (enc *Encoder) Int64(v int64) {
 	enc.grow(10)
-	r := enc.getPreviousRune()
-	if r != '[' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '[' {
 		enc.writeByte(',')
 	}
 	enc.buf = strconv.AppendInt(enc.buf, v, 10)
@@ -210,8 +210,8 @@ func (enc *Encoder) Int64OmitEmpty(v int64) {
 		return
 	}
 	enc.grow(10)
-	r := enc.getPreviousRune()
-	if r != '[' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '[' {
 		enc.writeByte(',')
 	}
 	enc.buf = strconv.AppendInt(enc.buf, v, 10)
@@ -221,8 +221,8 @@ func (enc *Encoder) Int64OmitEmpty(v int64) {
 // must be used inside a slice or array encoding (does not encode a key).
 func (enc *Encoder) Int64NullEmpty(v int64) {
 	enc.grow(10)
-	r := enc.getPreviousRune()
-	if r != '[' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '[' {
 		enc.writeByte(',')
 	}
 	if v == 0 {
@@ -257,8 +257,8 @@ func (enc *Encoder) Int64Key(key string, v int64) {
 		}
 	}
 	enc.grow(10 + len(key))
-	r := enc.getPreviousRune()
-	if r != '{' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '{' {
 		enc.writeByte(',')
 	}
 	enc.writeByte('"')
@@ -274,8 +274,8 @@ func (enc *Encoder) Int64KeyOmitEmpty(key string, v int64) {
 		return
 	}
 	enc.grow(10 + len(key))
-	r := enc.getPreviousRune()
-	if r != '{' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '{' {
 		enc.writeByte(',')
 	}
 	enc.writeByte('"')
@@ -293,8 +293,8 @@ func (enc *Encoder) Int64KeyNullEmpty(key string, v int64) {
 		}
 	}
 	enc.grow(10 + len(key))
-	r := enc.getPreviousRune()
-	if r != '{' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '{' {
 		enc.writeByte(',')
 	}
 	enc.writeByte('"')

--- a/encode_number_uint.go
+++ b/encode_number_uint.go
@@ -41,8 +41,8 @@ func (enc *Encoder) AddUint64NullEmpty(v uint64) {
 // Uint64 adds an int to be encoded, must be used inside a slice or array encoding (does not encode a key)
 func (enc *Encoder) Uint64(v uint64) {
 	enc.grow(10)
-	r := enc.getPreviousRune()
-	if r != '[' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '[' {
 		enc.writeByte(',')
 	}
 	enc.buf = strconv.AppendUint(enc.buf, v, 10)
@@ -55,8 +55,8 @@ func (enc *Encoder) Uint64OmitEmpty(v uint64) {
 		return
 	}
 	enc.grow(10)
-	r := enc.getPreviousRune()
-	if r != '[' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '[' {
 		enc.writeByte(',')
 	}
 	enc.buf = strconv.AppendUint(enc.buf, v, 10)
@@ -66,8 +66,8 @@ func (enc *Encoder) Uint64OmitEmpty(v uint64) {
 // must be used inside a slice or array encoding (does not encode a key).
 func (enc *Encoder) Uint64NullEmpty(v uint64) {
 	enc.grow(10)
-	r := enc.getPreviousRune()
-	if r != '[' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '[' {
 		enc.writeByte(',')
 	}
 	if v == 0 {
@@ -102,8 +102,8 @@ func (enc *Encoder) Uint64Key(key string, v uint64) {
 		}
 	}
 	enc.grow(10 + len(key))
-	r := enc.getPreviousRune()
-	if r != '{' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '{' {
 		enc.writeByte(',')
 	}
 	enc.writeByte('"')
@@ -124,8 +124,8 @@ func (enc *Encoder) Uint64KeyOmitEmpty(key string, v uint64) {
 		return
 	}
 	enc.grow(10 + len(key))
-	r := enc.getPreviousRune()
-	if r != '{' && r != '[' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '{' && r != '[' {
 		enc.writeByte(',')
 	}
 	enc.writeByte('"')
@@ -143,8 +143,8 @@ func (enc *Encoder) Uint64KeyNullEmpty(key string, v uint64) {
 		}
 	}
 	enc.grow(10 + len(key))
-	r := enc.getPreviousRune()
-	if r != '{' && r != '[' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '{' && r != '[' {
 		enc.writeByte(',')
 	}
 	enc.writeByte('"')

--- a/encode_object.go
+++ b/encode_object.go
@@ -102,8 +102,8 @@ func (enc *Encoder) AddObjectKeyNullEmpty(key string, v MarshalerJSONObject) {
 func (enc *Encoder) Object(v MarshalerJSONObject) {
 	if v.IsNil() {
 		enc.grow(2)
-		r := enc.getPreviousRune()
-		if r != '{' && r != '[' {
+		r, ok := enc.getPreviousRune()
+		if ok && r != '{' && r != '[' {
 			enc.writeByte(',')
 		}
 		enc.writeByte('{')
@@ -111,8 +111,8 @@ func (enc *Encoder) Object(v MarshalerJSONObject) {
 		return
 	}
 	enc.grow(4)
-	r := enc.getPreviousRune()
-	if r != '[' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '[' {
 		enc.writeByte(',')
 	}
 	enc.writeByte('{')
@@ -135,8 +135,8 @@ func (enc *Encoder) Object(v MarshalerJSONObject) {
 func (enc *Encoder) ObjectWithKeys(v MarshalerJSONObject, keys []string) {
 	if v.IsNil() {
 		enc.grow(2)
-		r := enc.getPreviousRune()
-		if r != '{' && r != '[' {
+		r, ok := enc.getPreviousRune()
+		if ok && r != '{' && r != '[' {
 			enc.writeByte(',')
 		}
 		enc.writeByte('{')
@@ -144,8 +144,8 @@ func (enc *Encoder) ObjectWithKeys(v MarshalerJSONObject, keys []string) {
 		return
 	}
 	enc.grow(4)
-	r := enc.getPreviousRune()
-	if r != '[' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '[' {
 		enc.writeByte(',')
 	}
 	enc.writeByte('{')
@@ -171,8 +171,8 @@ func (enc *Encoder) ObjectOmitEmpty(v MarshalerJSONObject) {
 		return
 	}
 	enc.grow(2)
-	r := enc.getPreviousRune()
-	if r != '[' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '[' {
 		enc.writeByte(',')
 	}
 	enc.writeByte('{')
@@ -195,8 +195,8 @@ func (enc *Encoder) ObjectOmitEmpty(v MarshalerJSONObject) {
 // value must implement MarshalerJSONObject
 func (enc *Encoder) ObjectNullEmpty(v MarshalerJSONObject) {
 	enc.grow(2)
-	r := enc.getPreviousRune()
-	if r != '[' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '[' {
 		enc.writeByte(',')
 	}
 	if v.IsNil() {
@@ -228,8 +228,8 @@ func (enc *Encoder) ObjectKey(key string, v MarshalerJSONObject) {
 	}
 	if v.IsNil() {
 		enc.grow(2 + len(key))
-		r := enc.getPreviousRune()
-		if r != '{' {
+		r, ok := enc.getPreviousRune()
+		if ok && r != '{' {
 			enc.writeByte(',')
 		}
 		enc.writeByte('"')
@@ -239,8 +239,8 @@ func (enc *Encoder) ObjectKey(key string, v MarshalerJSONObject) {
 		return
 	}
 	enc.grow(5 + len(key))
-	r := enc.getPreviousRune()
-	if r != '{' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '{' {
 		enc.writeByte(',')
 	}
 	enc.writeByte('"')
@@ -270,8 +270,8 @@ func (enc *Encoder) ObjectKeyWithKeys(key string, value MarshalerJSONObject, key
 	}
 	if value.IsNil() {
 		enc.grow(2 + len(key))
-		r := enc.getPreviousRune()
-		if r != '{' {
+		r, ok := enc.getPreviousRune()
+		if ok && r != '{' {
 			enc.writeByte(',')
 		}
 		enc.writeByte('"')
@@ -281,8 +281,8 @@ func (enc *Encoder) ObjectKeyWithKeys(key string, value MarshalerJSONObject, key
 		return
 	}
 	enc.grow(5 + len(key))
-	r := enc.getPreviousRune()
-	if r != '{' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '{' {
 		enc.writeByte(',')
 	}
 	enc.writeByte('"')
@@ -311,8 +311,8 @@ func (enc *Encoder) ObjectKeyOmitEmpty(key string, v MarshalerJSONObject) {
 		return
 	}
 	enc.grow(5 + len(key))
-	r := enc.getPreviousRune()
-	if r != '{' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '{' {
 		enc.writeByte(',')
 	}
 	enc.writeByte('"')
@@ -342,8 +342,8 @@ func (enc *Encoder) ObjectKeyNullEmpty(key string, v MarshalerJSONObject) {
 		}
 	}
 	enc.grow(5 + len(key))
-	r := enc.getPreviousRune()
-	if r != '{' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '{' {
 		enc.writeByte(',')
 	}
 	enc.writeByte('"')

--- a/encode_string.go
+++ b/encode_string.go
@@ -67,8 +67,8 @@ func (enc *Encoder) AddStringKeyNullEmpty(key, v string) {
 // String adds a string to be encoded, must be used inside a slice or array encoding (does not encode a key)
 func (enc *Encoder) String(v string) {
 	enc.grow(len(v) + 4)
-	r := enc.getPreviousRune()
-	if r != '[' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '[' {
 		enc.writeTwoBytes(',', '"')
 	} else {
 		enc.writeByte('"')
@@ -83,8 +83,8 @@ func (enc *Encoder) StringOmitEmpty(v string) {
 	if v == "" {
 		return
 	}
-	r := enc.getPreviousRune()
-	if r != '[' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '[' {
 		enc.writeTwoBytes(',', '"')
 	} else {
 		enc.writeByte('"')
@@ -96,9 +96,9 @@ func (enc *Encoder) StringOmitEmpty(v string) {
 // StringNullEmpty adds a string to be encoded or skips it if it is zero value.
 // Must be used inside a slice or array encoding (does not encode a key)
 func (enc *Encoder) StringNullEmpty(v string) {
-	r := enc.getPreviousRune()
+	r, ok := enc.getPreviousRune()
 	if v == "" {
-		if r != '[' {
+		if ok && r != '[' {
 			enc.writeByte(',')
 			enc.writeBytes(nullBytes)
 		} else {
@@ -123,8 +123,8 @@ func (enc *Encoder) StringKey(key, v string) {
 		}
 	}
 	enc.grow(len(key) + len(v) + 5)
-	r := enc.getPreviousRune()
-	if r != '{' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '{' {
 		enc.writeTwoBytes(',', '"')
 	} else {
 		enc.writeByte('"')
@@ -147,8 +147,8 @@ func (enc *Encoder) StringKeyOmitEmpty(key, v string) {
 		return
 	}
 	enc.grow(len(key) + len(v) + 5)
-	r := enc.getPreviousRune()
-	if r != '{' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '{' {
 		enc.writeTwoBytes(',', '"')
 	} else {
 		enc.writeByte('"')
@@ -168,8 +168,8 @@ func (enc *Encoder) StringKeyNullEmpty(key, v string) {
 		}
 	}
 	enc.grow(len(key) + len(v) + 5)
-	r := enc.getPreviousRune()
-	if r != '{' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '{' {
 		enc.writeTwoBytes(',', '"')
 	} else {
 		enc.writeByte('"')

--- a/encode_time.go
+++ b/encode_time.go
@@ -38,8 +38,8 @@ func (enc *Encoder) TimeKey(key string, t *time.Time, format string) {
 		}
 	}
 	enc.grow(10 + len(key))
-	r := enc.getPreviousRune()
-	if r != '{' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '{' {
 		enc.writeTwoBytes(',', '"')
 	} else {
 		enc.writeByte('"')
@@ -58,8 +58,8 @@ func (enc *Encoder) AddTime(t *time.Time, format string) {
 // Time adds an *time.Time to be encoded with the given format, must be used inside a slice or array encoding (does not encode a key)
 func (enc *Encoder) Time(t *time.Time, format string) {
 	enc.grow(10)
-	r := enc.getPreviousRune()
-	if r != '[' {
+	r, ok := enc.getPreviousRune()
+	if ok && r != '[' {
 		enc.writeByte(',')
 	}
 	enc.writeByte('"')


### PR DESCRIPTION
The encoder panics while encoding values explicitly since there is no previous rune:
```go
package main

import (
	"strings"

	"github.com/francoispqt/gojay"
)

func main() {
	var (
		buff    strings.Builder
		encoder = gojay.BorrowEncoder(&buff)
	)
	defer encoder.Release()

	encoder.Float64(42) // or AddFloat ... AddXxxx ...
}
```
the output will be:
```
panic: runtime error: index out of range [-1]

goroutine 1 [running]:
github.com/francoispqt/gojay.(*Encoder).getPreviousRune(...)
	/tmp/gopath957066451/pkg/mod/github.com/francoispqt/gojay@v1.2.13/encode.go:201
github.com/francoispqt/gojay.(*Encoder).Float64(0xc0000bb920, 0x4045000000000000)
	/tmp/gopath957066451/pkg/mod/github.com/francoispqt/gojay@v1.2.13/encode_number_float.go:124 +0x205
github.com/francoispqt/gojay.(*Encoder).Float(...)
	/tmp/gopath957066451/pkg/mod/github.com/francoispqt/gojay@v1.2.13/encode_number_float.go:61
github.com/francoispqt/gojay.(*Encoder).AddFloat64(...)
	/tmp/gopath957066451/pkg/mod/github.com/francoispqt/gojay@v1.2.13/encode_number_float.go:112
main.main()
	/tmp/sandbox969752132/prog.go:17 +0x85
```
fix: check the length of the buffer in order to avoid panics