### PR TITLE
Feature: DecodeArray, Add the ability to skip reading an array

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -235,16 +235,17 @@ type UnmarshalerJSONArray interface {
 
 // A Decoder reads and decodes JSON values from an input stream.
 type Decoder struct {
-	r          io.Reader
-	data       []byte
-	err        error
-	isPooled   byte
-	called     byte
-	child      byte
-	cursor     int
-	length     int
-	keysDone   int
-	arrayIndex int
+	r                  io.Reader
+	data               []byte
+	err                error
+	isPooled           byte
+	called             byte
+	child              byte
+	cursor             int
+	length             int
+	keysDone           int
+	arrayIndex         int
+	skipArrayDataBlock bool
 }
 
 // Decode reads the next JSON-encoded value from the decoder's input (io.Reader) and stores it in the value pointed to by v.
@@ -326,6 +327,13 @@ func (dec *Decoder) Decode(v interface{}) error {
 		return err
 	}
 	return dec.err
+}
+
+
+// SkipArrayDataBlock allows the decoder to move the cursor forward quickly to the next key
+// useful to limiting the amount of data marshalled in arrays if some limit length is set
+func (dec *Decoder) SkipArrayDataBlock() {
+	dec.skipArrayDataBlock = true
 }
 
 // Non exported

--- a/decode_array.go
+++ b/decode_array.go
@@ -1,6 +1,8 @@
 package gojay
 
-import "reflect"
+import (
+	"reflect"
+)
 
 // DecodeArray reads the next JSON-encoded value from the decoder's input (io.Reader)
 // and stores it in the value pointed to by v.
@@ -33,8 +35,15 @@ func (dec *Decoder) decodeArray(arr UnmarshalerJSONArray) (int, error) {
 				// closing array
 				if dec.data[dec.cursor] == ']' {
 					dec.cursor = dec.cursor + 1
+					dec.skipArrayDataBlock =  false
 					return dec.cursor, nil
 				}
+
+				if dec.skipArrayDataBlock {
+					dec.cursor = dec.cursor + 1
+					continue
+				}
+
 				// calling unmarshall function for each element of the slice
 				err := arr.UnmarshalJSONArray(dec)
 				if err != nil {


### PR DESCRIPTION
This allows the user to set a limit on the size of the array. Once the size is met, instead of continuing to read in the data eating cpu to move the cursor, we can fast iterate and move the cursor without decoding anymore data, see the test for an example on how it works. I came across this issue in production. It makes the cpu run very hot even when I limit the size because in order to move the cursor to throw away the data, you need to call a decode method.