### PR TITLE
Improper Signature Verification.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/stretchr/testify v1.2.2
 	github.com/viant/assertly v0.4.8
 	github.com/viant/toolbox v0.24.0
-	golang.org/x/crypto v0.0.0-20190313024323-a1f597ede03a // indirect
+	golang.org/x/crypto@0.0.0-20201203163018-be400aefbc4c // indirect
 	golang.org/x/net v0.0.0-20190313220215-9f648a60d977
 	golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421 // indirect
 	golang.org/x/sys v0.0.0-20190316082340-a2f829d7f35f // indirect


### PR DESCRIPTION
golang.org/x/crypto/ 

Affected versions of this package are vulnerable to Improper Signature Verification. An attacker can craft an ssh-ed25519 or sk-ssh-...@openssh.com public key, such that the library will panic when trying to verify a signature with it. Clients can deliver such a public key and signature to any golang.org/x/crypto/ssh server with a PublicKeyCallback, and servers can deliver them to any golang.org/x/crypto/ssh client.